### PR TITLE
Fix: UI cleanup of the covid tracker activity to make the state selection spanner visible 

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,13 +3,16 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="..\:/Users/rishu/Desktop/Hactoberfest/CovidHelp/app/src/main/res/drawable/dropdownwhite.xml" value="0.1" />
+        <entry key="..\:/Users/rishu/Desktop/Hactoberfest/CovidHelp/app/src/main/res/drawable/spanner.xml" value="0.26614583333333336" />
+        <entry key="..\:/Users/rishu/Desktop/Hactoberfest/CovidHelp/app/src/main/res/layout/covid_tracker_activity.xml" value="0.1" />
         <entry key="..\:/android_project_folder/Big Projects/CovidHelp/app/src/main/res/layout/activity_choose.xml" value="0.14764492753623187" />
         <entry key="..\:/android_project_folder/Big Projects/CovidHelp/app/src/main/res/layout/activity_main.xml" value="0.1" />
         <entry key="..\:/android_project_folder/Big Projects/CovidHelp/app/src/main/res/layout/fragment_home.xml" value="0.14764492753623187" />
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_15_PREVIEW" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/res/drawable/dropdownwhite.xml
+++ b/app/src/main/res/drawable/dropdownwhite.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/white">
+    <path
+        android:fillColor="@color/white"
+        android:pathData="M7,10l5,5 5,-5z"/>
+</vector>

--- a/app/src/main/res/drawable/spanner.xml
+++ b/app/src/main/res/drawable/spanner.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+
+    <item>
+
+
+        <layer-list>
+            <item>
+                <shape xmlns:android="http://schemas.android.com/apk/res/android"
+                    android:shape="rectangle"
+                    android:padding="10dp">
+
+                    <stroke android:width="1dp"
+                        android:color="@color/white"/>
+
+                    <corners android:radius="3dp"/>
+                </shape>
+            </item>
+
+            <item android:drawable="@drawable/dropdownwhite" android:gravity="right" android:right="5dp"/>
+        </layer-list>
+    </item>
+</selector>

--- a/app/src/main/res/layout/covid_tracker_activity.xml
+++ b/app/src/main/res/layout/covid_tracker_activity.xml
@@ -29,32 +29,38 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
-
-        <RelativeLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:background="@color/black">
-
-            <org.eazegraph.lib.charts.BarChart
-                android:id="@+id/barchart"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:padding="10dp"
-                android:layout_marginTop="30dp"
-                android:layout_marginStart="30dp"
-                android:layout_marginEnd="30dp"
-                app:egBarWidth="20dp"
-                app:egFixedBarWidth="true"
-                app:egLegendHeight="40dp" />
+            android:layout_height="wrap_content">
 
             <Spinner
                 android:id="@+id/spinnerSelectState"
-                android:layout_width="wrap_content"
+                android:paddingStart="5dp"
+                android:paddingEnd="2dp"
+                android:layout_width="250dp"
+                android:layout_height="35dp"
                 android:layout_marginStart="10dp"
                 android:layout_marginTop="10dp"
-                android:layout_height="25dp" />
-        </RelativeLayout>
+
+                android:background="@drawable/spanner"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <org.eazegraph.lib.charts.BarChart
+            android:id="@+id/barchart"
+            android:layout_width="346dp"
+            android:layout_height="312dp"
+            android:layout_marginStart="30dp"
+            android:layout_marginTop="30dp"
+            android:layout_marginEnd="30dp"
+            android:padding="10dp"
+            app:egBarWidth="20dp"
+            app:egFixedBarWidth="true"
+            app:egLegendHeight="40dp" />
+
+
 
         <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
UI cleanup of the covid tracker activity to make the state selection spanner visible  referencing issue #7  

![image](https://user-images.githubusercontent.com/72988817/135666852-c940b3f1-164d-49b7-aa27-7044ee1eddc8.png)
